### PR TITLE
PHP Strict Notice fix for get_object()

### DIFF
--- a/wp-admin-style.php
+++ b/wp-admin-style.php
@@ -64,7 +64,7 @@ class Wp_Admin_Style {
 	 * @since 0.0.1
 	 * @return object
 	 */
-	public function get_object() {
+	public static function get_object() {
 		
 		if ( NULL === self :: $classobj )
 			self :: $classobj = new self;


### PR DESCRIPTION
Hyia,

Not a big deal, just noticed a strict-level notice in the instantiation process for the plugin:

```
call_user_func_array() expects parameter 1 to be a valid callback, non-static method Wp_Admin_Style::get_object() should not be called statically on line 406 in file /var/www/wp-includes/plugin.php
```

Love the plugin, by the way. It's been a big help to me. Thanks for making it!
