### PR TITLE
Change the menu slug for compatibility with different directory name

### DIFF
--- a/inc/wp-admin-jquery-ui.php
+++ b/inc/wp-admin-jquery-ui.php
@@ -52,7 +52,7 @@ class Wp_Admin_Jquery_Ui {
 	public function register_submenu() {
 		
 		$hook = add_submenu_page(
-			'WordPress-Admin-Style/wp-admin-style.php',
+			'WordPress_Admin_Style',
 			__( 'jQuery UI Demo' ),
 			__( 'jQuery UI' ),
 			'manage_options',

--- a/inc/wp-dashicons.php
+++ b/inc/wp-dashicons.php
@@ -57,7 +57,7 @@ class Wp_Admin_Dashicons {
 	public function register_submenu() {
 		
 		$hook = add_submenu_page(
-			'WordPress-Admin-Style/wp-admin-style.php',
+			'WordPress_Admin_Style',
 			__( 'Dashicons' ),
 			__( 'Dashicons' ),
 			'manage_options',

--- a/inc/wp-genericons.php
+++ b/inc/wp-genericons.php
@@ -57,7 +57,7 @@ class Wp_Admin_Genericons {
 	public function register_submenu() {
 		
 		$hook = add_submenu_page(
-			'WordPress-Admin-Style/wp-admin-style.php',
+			'WordPress_Admin_Style',
 			__( 'Genericons' ),
 			__( 'Genericons' ),
 			'manage_options',

--- a/wp-admin-style.php
+++ b/wp-admin-style.php
@@ -157,7 +157,7 @@ class Wp_Admin_Style {
 			__( 'WordPress Admin Style', 'wp_admin_style' ),
 			__( 'Admin Style', 'wp_admin_style' ),
 			'read',
-			__FILE__,
+			'WordPress_Admin_Style',
 			array( $this, 'get_style_examples' )
 		);
 	}


### PR DESCRIPTION
If you download the plugin by clicking the GitHub download button and don't rename the plugin folder before activating, the submenus won't show up, which can be pretty annoying. I used a fixed slug for the menu so that it can work with any directory name.
